### PR TITLE
No longer start on boot automatically

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -39,8 +39,6 @@ do_configure() {
 		chown asterisk:asterisk /var/lib/asterisk
 	fi
 
-	# install systemd timer (update nodelist)
-	deb-systemd-invoke enable asl3-update-nodelist.timer
 }
 
 case "$1" in


### PR DESCRIPTION
This change is to no longer start this on boot for new installations. It will not impact existing installations.