### PR TITLE
Fix mktemp leak when node_lookup_method is dns

### DIFF
--- a/asl3-update-nodelist
+++ b/asl3-update-nodelist
@@ -28,7 +28,6 @@ USERAGENT="asl3-update-nodelist/1.0"
 FILEPATH=/var/lib/asterisk
 NODELIST=rpt_extnodes
 EXTNODES=$FILEPATH/$NODELIST
-EXTNODESTMP=$(mktemp)
 HASH_FILE=$FILEPATH/asl3un-hash
 
 getLastHash() {
@@ -72,6 +71,7 @@ getLastHash
 [ "${last_hash}" != '' ] && QS="?hash=${last_hash}"
 
 # Download the Nodelist
+EXTNODESTMP=$(mktemp)
 downloadNodelist "${QS}"
 
 diff_type=$(head -n1 ${EXTNODESTMP} | sed -e 's/^;//g')


### PR DESCRIPTION
## Summary
- Move `EXTNODESTMP=$(mktemp)` to after the `node_lookup_method = dns` early exit
- Prevents `asl3-update-nodelist.timer` from leaking empty `/tmp/tmp.*` files on nodes configured for DNS node lookup

## Background
On nodes with `node_lookup_method = dns` in `rpt.conf`, the script correctly skips downloading the on-disk nodelist, but previously created a temp file at startup and exited before `rm $EXTNODESTMP`. The timer runs every ~3–4 minutes as `asterisk`, so these empty files accumulate indefinitely.

## Test plan
- [ ] Set `node_lookup_method = dns` in `rpt.conf`
- [ ] Run `systemctl start asl3-update-nodelist.service` several times
- [ ] Confirm no new `/tmp/tmp.*` files owned by `asterisk` appear
- [ ] With `node_lookup_method` set to `file` (or unset), confirm nodelist download still works