### PR TITLE
Throttle rpt_extnodes updates when node_lookup_method is both

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ systemctl start asl3-update-nodelist.timer
 
 ## Customizing throttle settings
 
-When `node_lookup_method = both`, override `BOTH_UPDATE_INTERVAL` and
-`DNS_PROBE_NODE` with:
+When `node_lookup_method = both`, override `BOTH_UPDATE_INTERVAL` with:
 
 ```bash
 systemctl edit asl3-update-nodelist.service
@@ -43,10 +42,9 @@ Add lines such as:
 ```ini
 [Service]
 Environment=BOTH_UPDATE_INTERVAL=43200
-Environment=DNS_PROBE_NODE=2000
 ```
 
-Do not edit `/usr/bin/asl3-update-nodelist` to change these values.
+Do not edit `/usr/bin/asl3-update-nodelist` to change this value.
 
 ## Resetting Database State
 To reset after a suspected database corruption:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,29 @@ and conflicts with, the asl-update-node-list package for
 ASL2. Use one or the other, but not both.
 
 On installation of the package, the `asl3-update-nodelist.timer`
-is enabled and will update the database one every 60 seconds
-using the full/differential method.
+is not enabled automatically. When enabled, it updates the database
+every 180 seconds using the full/differential method.
+
+### node_lookup_method behavior
+
+The updater reads `node_lookup_method` from `/etc/asterisk/rpt.conf`
+and adjusts its behavior accordingly:
+
+| Method | Behavior |
+|--------|----------|
+| `dns` | Skips updates; `rpt_extnodes` is not consulted by app_rpt |
+| `file` | Updates on every timer run |
+| `both` | Skips updates when DNS is healthy and `rpt_extnodes` was refreshed within the last 24 hours; updates when DNS is unavailable or the file is older than 24 hours |
+
+The throttle interval can be overridden with `ASL3UN_BOTH_INTERVAL`
+(see `asl3-update-nodelist(1)`).
+
+To enable the nodelist updater:
+
+```bash
+systemctl enable asl3-update-nodelist.timer
+systemctl start asl3-update-nodelist.timer
+```
 
 ## Resetting Database State
 To reset after a suspected database corruption:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and adjusts its behavior accordingly:
 | `file` | Updates on every timer run |
 | `both` | Skips updates when DNS is healthy and `rpt_extnodes` was refreshed within the last 24 hours; updates when DNS is unavailable or the file is older than 24 hours |
 
-The throttle interval can be overridden with `ASL3UN_BOTH_INTERVAL`
+The throttle interval can be overridden with `BOTH_UPDATE_INTERVAL`
 (see `asl3-update-nodelist(1)`).
 
 To enable the nodelist updater:
@@ -28,6 +28,25 @@ To enable the nodelist updater:
 systemctl enable asl3-update-nodelist.timer
 systemctl start asl3-update-nodelist.timer
 ```
+
+## Customizing throttle settings
+
+When `node_lookup_method = both`, override `BOTH_UPDATE_INTERVAL` and
+`DNS_PROBE_NODE` with:
+
+```bash
+systemctl edit asl3-update-nodelist.service
+```
+
+Add lines such as:
+
+```ini
+[Service]
+Environment=BOTH_UPDATE_INTERVAL=43200
+Environment=DNS_PROBE_NODE=2000
+```
+
+Do not edit `/usr/bin/asl3-update-nodelist` to change these values.
 
 ## Resetting Database State
 To reset after a suspected database corruption:

--- a/asl3-update-nodelist
+++ b/asl3-update-nodelist
@@ -31,8 +31,10 @@ EXTNODES=$FILEPATH/$NODELIST
 HASH_FILE=$FILEPATH/asl3un-hash
 
 # both-mode throttle: rpt_extnodes is DNS failover only (see issue #11)
-BOTH_UPDATE_INTERVAL=${ASL3UN_BOTH_INTERVAL:-86400}
-DNS_PROBE_NODE=${ASL3UN_DNS_PROBE_NODE:-2000}
+# BOTH_UPDATE_INTERVAL and DNS_PROBE_NODE may be overridden via
+# systemctl edit asl3-update-nodelist.service (see asl3-update-nodelist(1)).
+BOTH_UPDATE_INTERVAL=${BOTH_UPDATE_INTERVAL:-86400}
+DNS_PROBE_NODE=${DNS_PROBE_NODE:-2000}
 DEFAULT_DNS_NODE_DOMAIN=nodes.allstarlink.org
 
 getLastHash() {
@@ -62,14 +64,14 @@ writeNodelist() {
 }
 
 dnsProbe() {
-	local domain probe dom
+	local domain probe
 
 	if [ -r /etc/asterisk/rpt.conf ]; then
-		dom=$(grep -iE '^dns_node_domain' /etc/asterisk/rpt.conf | \
+		domain=$(grep -iE '^dns_node_domain' /etc/asterisk/rpt.conf | \
 			perl -pe 's/^dns_node_domain\s?=\s?(\S+).*$/$1/gi' | \
-			tr '[:upper:]' '[:lower:]' | head -n1)
+			tr '[:upper:]' '[:lower:]' | tail -n1)
 	fi
-	domain=${dom:-${DEFAULT_DNS_NODE_DOMAIN}}
+	domain=${domain:-${DEFAULT_DNS_NODE_DOMAIN}}
 	probe="_iax._udp.${DNS_PROBE_NODE}.${domain}"
 	host -t SRV "${probe}" >/dev/null 2>&1
 }
@@ -97,8 +99,9 @@ shouldThrottleBothMode() {
 }
 
 # Check to see if this host is even using me
+# Values are read from /etc/asterisk/rpt.conf directly (not #include files).
 LUT=$( grep -iE '^node_lookup_method' /etc/asterisk/rpt.conf | \
-	perl -pe 's/^node_lookup_method\s?=\s?(\S+).*$/$1/gi' | tr '[A-Z]' '[a-z]')
+	perl -pe 's/^node_lookup_method\s?=\s?(\S+).*$/$1/gi' | tr '[A-Z]' '[:lower:]' | tail -n1)
 if [ "x${LUT}" = "xdns" ]; then
 	echo "node_lookup_method = dns; skipping"
 	exit 0

--- a/asl3-update-nodelist
+++ b/asl3-update-nodelist
@@ -30,6 +30,11 @@ NODELIST=rpt_extnodes
 EXTNODES=$FILEPATH/$NODELIST
 HASH_FILE=$FILEPATH/asl3un-hash
 
+# both-mode throttle: rpt_extnodes is DNS failover only (see issue #11)
+BOTH_UPDATE_INTERVAL=${ASL3UN_BOTH_INTERVAL:-86400}
+DNS_PROBE_NODE=${ASL3UN_DNS_PROBE_NODE:-2000}
+DEFAULT_DNS_NODE_DOMAIN=nodes.allstarlink.org
+
 getLastHash() {
 	last_hash=$(head -n1 ${HASH_FILE})
 }
@@ -56,11 +61,51 @@ writeNodelist() {
 	#echo "${NODELIST} updated"
 }
 
+dnsProbe() {
+	local domain probe dom
+
+	if [ -r /etc/asterisk/rpt.conf ]; then
+		dom=$(grep -iE '^dns_node_domain' /etc/asterisk/rpt.conf | \
+			perl -pe 's/^dns_node_domain\s?=\s?(\S+).*$/$1/gi' | \
+			tr '[:upper:]' '[:lower:]' | head -n1)
+	fi
+	domain=${dom:-${DEFAULT_DNS_NODE_DOMAIN}}
+	probe="_iax._udp.${DNS_PROBE_NODE}.${domain}"
+	host -t SRV "${probe}" >/dev/null 2>&1
+}
+
+# Return 0 when a both-mode update should be skipped.
+shouldThrottleBothMode() {
+	local now file_mtime file_age
+
+	if [ ! -s "${EXTNODES}" ]; then
+		return 1
+	fi
+
+	now=$(date +%s)
+	file_mtime=$(stat -c %Y "${EXTNODES}" 2>/dev/null || echo 0)
+	file_age=$(( now - file_mtime ))
+	if [ "${file_age}" -ge "${BOTH_UPDATE_INTERVAL}" ]; then
+		return 1
+	fi
+
+	if ! dnsProbe; then
+		return 1
+	fi
+
+	return 0
+}
+
 # Check to see if this host is even using me
 LUT=$( grep -iE '^node_lookup_method' /etc/asterisk/rpt.conf | \
 	perl -pe 's/^node_lookup_method\s?=\s?(\S+).*$/$1/gi' | tr '[A-Z]' '[a-z]')
 if [ "x${LUT}" = "xdns" ]; then
 	echo "node_lookup_method = dns; skipping"
+	exit 0
+fi
+
+if [ "x${LUT}" = "xboth" ] && shouldThrottleBothMode; then
+	echo "node_lookup_method = both; skipping"
 	exit 0
 fi
 
@@ -82,6 +127,7 @@ case $diff_type in
 		;;
 
 	Empty)
+		touch ${EXTNODES}
 		#echo "${NODELIST} unchanged"
 		;;
 

--- a/asl3-update-nodelist
+++ b/asl3-update-nodelist
@@ -31,10 +31,9 @@ EXTNODES=$FILEPATH/$NODELIST
 HASH_FILE=$FILEPATH/asl3un-hash
 
 # both-mode throttle: rpt_extnodes is DNS failover only (see issue #11)
-# BOTH_UPDATE_INTERVAL and DNS_PROBE_NODE may be overridden via
+# BOTH_UPDATE_INTERVAL may be overridden via
 # systemctl edit asl3-update-nodelist.service (see asl3-update-nodelist(1)).
 BOTH_UPDATE_INTERVAL=${BOTH_UPDATE_INTERVAL:-86400}
-DNS_PROBE_NODE=${DNS_PROBE_NODE:-2000}
 DEFAULT_DNS_NODE_DOMAIN=nodes.allstarlink.org
 
 getLastHash() {
@@ -63,8 +62,9 @@ writeNodelist() {
 	#echo "${NODELIST} updated"
 }
 
+# Return 0 when the node DNS domain appears reachable.
 dnsProbe() {
-	local domain probe
+	local domain
 
 	if [ -r /etc/asterisk/rpt.conf ]; then
 		domain=$(grep -iE '^dns_node_domain' /etc/asterisk/rpt.conf | \
@@ -72,8 +72,7 @@ dnsProbe() {
 			tr '[:upper:]' '[:lower:]' | tail -n1)
 	fi
 	domain=${domain:-${DEFAULT_DNS_NODE_DOMAIN}}
-	probe="_iax._udp.${DNS_PROBE_NODE}.${domain}"
-	host -t SRV "${probe}" >/dev/null 2>&1
+	host -t SOA "${domain}" >/dev/null 2>&1
 }
 
 # Return 0 when a both-mode update should be skipped.
@@ -101,7 +100,7 @@ shouldThrottleBothMode() {
 # Check to see if this host is even using me
 # Values are read from /etc/asterisk/rpt.conf directly (not #include files).
 LUT=$( grep -iE '^node_lookup_method' /etc/asterisk/rpt.conf | \
-	perl -pe 's/^node_lookup_method\s?=\s?(\S+).*$/$1/gi' | tr '[A-Z]' '[:lower:]' | tail -n1)
+	perl -pe 's/^node_lookup_method\s?=\s?(\S+).*$/$1/gi' | tr '[:upper:]' '[:lower:]' | tail -n1)
 if [ "x${LUT}" = "xdns" ]; then
 	echo "node_lookup_method = dns; skipping"
 	exit 0

--- a/asl3-update-nodelist.1.md
+++ b/asl3-update-nodelist.1.md
@@ -14,7 +14,8 @@ to `/var/lib/asterisk/rpt_extnodes` using the full/diff/empty
 strategy offered by `https://snodes.allstarlink.org/diffnodes.php`.
 
 The command reads `node_lookup_method` from `/etc/asterisk/rpt.conf`
-and adjusts its behavior:
+directly (not from `#include` or `#tryinclude` files) and adjusts
+its behavior:
 
 **dns**
 :   Exits without downloading. app_rpt does not consult `rpt_extnodes`.
@@ -29,9 +30,24 @@ and adjusts its behavior:
     is bypassed when the file is missing, older than 24 hours, or DNS
     probing fails.
 
-The throttle interval can be overridden with `ASL3UN_BOTH_INTERVAL`
-(seconds). `ASL3UN_DNS_PROBE_NODE` sets the node number used for DNS
-health checks (default 2000).
+# ENVIRONMENT
+
+**BOTH_UPDATE_INTERVAL**
+:   Seconds between throttled updates in `both` mode (default 86400).
+
+**DNS_PROBE_NODE**
+:   Node number used for DNS health checks (default 2000).
+
+These variables may be set in the service unit environment. Use
+**systemctl edit asl3-update-nodelist.service** to add override lines such as:
+
+```ini
+[Service]
+Environment=BOTH_UPDATE_INTERVAL=43200
+Environment=DNS_PROBE_NODE=2000
+```
+
+Do not edit `/usr/bin/asl3-update-nodelist` to change these values.
 
 The command is normally executed using asl3-update-nodelist.timer
 from systemd. It can be run by hand but only as the asterisk

--- a/asl3-update-nodelist.1.md
+++ b/asl3-update-nodelist.1.md
@@ -34,20 +34,18 @@ its behavior:
 
 **BOTH_UPDATE_INTERVAL**
 :   Seconds between throttled updates in `both` mode (default 86400).
+    DNS health is checked with an SOA query for `dns_node_domain`
+    (or `nodes.allstarlink.org` if unset).
 
-**DNS_PROBE_NODE**
-:   Node number used for DNS health checks (default 2000).
-
-These variables may be set in the service unit environment. Use
+This variable may be set in the service unit environment. Use
 **systemctl edit asl3-update-nodelist.service** to add override lines such as:
 
 ```ini
 [Service]
 Environment=BOTH_UPDATE_INTERVAL=43200
-Environment=DNS_PROBE_NODE=2000
 ```
 
-Do not edit `/usr/bin/asl3-update-nodelist` to change these values.
+Do not edit `/usr/bin/asl3-update-nodelist` to change this value.
 
 The command is normally executed using asl3-update-nodelist.timer
 from systemd. It can be run by hand but only as the asterisk

--- a/asl3-update-nodelist.1.md
+++ b/asl3-update-nodelist.1.md
@@ -12,8 +12,26 @@ usage: asl3-update-nodelist
 **asl3-update-nodelist** downloads the AllStarLink node database file
 to `/var/lib/asterisk/rpt_extnodes` using the full/diff/empty
 strategy offered by `https://snodes.allstarlink.org/diffnodes.php`.
-It will only act if node\_lookup\_method is not "dns" in
-/etc/asterisk/rpt.conf. Otherwise it will exit without error.
+
+The command reads `node_lookup_method` from `/etc/asterisk/rpt.conf`
+and adjusts its behavior:
+
+**dns**
+:   Exits without downloading. app_rpt does not consult `rpt_extnodes`.
+
+**file**
+:   Downloads on every invocation.
+
+**both**
+:   DNS is tried first by app_rpt and `rpt_extnodes` is used only as
+    failover. When DNS is healthy and `rpt_extnodes` was modified within
+    the last 24 hours, the command exits without downloading. The throttle
+    is bypassed when the file is missing, older than 24 hours, or DNS
+    probing fails.
+
+The throttle interval can be overridden with `ASL3UN_BOTH_INTERVAL`
+(seconds). `ASL3UN_DNS_PROBE_NODE` sets the node number used for DNS
+health checks (default 2000).
 
 The command is normally executed using asl3-update-nodelist.timer
 from systemd. It can be run by hand but only as the asterisk


### PR DESCRIPTION
## Summary

Addresses #11 by throttling flat-file downloads when `node_lookup_method = both` and DNS failover appears healthy.

- `dns` — unchanged; script exits without downloading
- `file` — unchanged; downloads on every timer run
- `both` — skips downloads when DNS probing succeeds and `rpt_extnodes` was refreshed within the last 24 hours; bypasses throttle when the file is missing, stale, or DNS is unavailable

This implements the script-side portion of the issue proposal without requiring `app_rpt` changes. The systemd timer interval is unchanged; throttling is handled inside `asl3-update-nodelist`.

## Test plan

- [x] `node_lookup_method = dns` — script skips, exits 0
- [x] `node_lookup_method = both` with healthy DNS and fresh file — script throttles, exits 0
- [x] `node_lookup_method = both` with stale file (>24h) — script downloads
- [x] `node_lookup_method = both` after successful download — throttle resumes
- [x] Verified via systemd timer on test node (crazytrain)